### PR TITLE
DEV: Change `target_classes` to be `target_user_field_ids`

### DIFF
--- a/assets/javascripts/discourse/connectors/after-admin-user-fields/custom-user-fields.gjs
+++ b/assets/javascripts/discourse/connectors/after-admin-user-fields/custom-user-fields.gjs
@@ -14,7 +14,6 @@ export default class CustomUserFields extends Component {
   @tracked userFieldsMinusCurrent = this.site.user_fields.filter(
     (userField) => userField.id !== this.args.outletArgs.buffered.content.id
   );
-  @tracked userFieldIds;
 
   constructor() {
     super(...arguments);

--- a/assets/javascripts/discourse/connectors/after-admin-user-fields/custom-user-fields.gjs
+++ b/assets/javascripts/discourse/connectors/after-admin-user-fields/custom-user-fields.gjs
@@ -1,15 +1,25 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { Input } from "@ember/component";
+import { inject as service } from "@ember/service";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import i18n from "discourse-common/helpers/i18n";
 import AdminFormRow from "admin/components/admin-form-row";
 import ValueList from "admin/components/value-list";
+import MultiSelect from "select-kit/components/multi-select";
 
 export default class CustomUserFields extends Component {
+  @service site;
+
+  @tracked userFieldsMinusCurrent = this.site.user_fields.filter(
+    (userField) => userField.id !== this.args.outletArgs.buffered.content.id
+  );
+  @tracked userFieldIds;
+
   constructor() {
     super(...arguments);
     withPluginApi("1.21.0", (api) => {
-      ["has_custom_validation", "show_values", "target_classes"].forEach(
+      ["has_custom_validation", "show_values", "target_user_field_ids"].forEach(
         (property) => api.includeUserFieldPropertyOnSave(property)
       );
     });
@@ -44,16 +54,17 @@ export default class CustomUserFields extends Component {
       </AdminFormRow>
 
       <AdminFormRow
-        @label="discourse_authentication_validations.target_classes.label"
+        @label="discourse_authentication_validations.target_user_field_ids.label"
       >
-        <ValueList
-          @values={{@outletArgs.buffered.target_classes}}
-          @inputType="array"
-          class="target-classes-input"
+        <MultiSelect
+          @content={{this.userFieldsMinusCurrent}}
+          @valueProperty={{"id"}}
+          @value={{@outletArgs.buffered.target_user_field_ids}}
         />
+        <br />
         <span>
           {{i18n
-            "discourse_authentication_validations.target_classes.description"
+            "discourse_authentication_validations.target_user_field_ids.description"
           }}
         </span>
       </AdminFormRow>

--- a/assets/javascripts/discourse/connectors/after-admin-user-fields/custom-user-fields.gjs
+++ b/assets/javascripts/discourse/connectors/after-admin-user-fields/custom-user-fields.gjs
@@ -58,7 +58,7 @@ export default class CustomUserFields extends Component {
       >
         <MultiSelect
           @content={{this.userFieldsMinusCurrent}}
-          @valueProperty={{"id"}}
+          @valueProperty="id"
           @value={{@outletArgs.buffered.target_user_field_ids}}
         />
         <br />

--- a/assets/javascripts/discourse/services/user-field-validations.js
+++ b/assets/javascripts/discourse/services/user-field-validations.js
@@ -36,7 +36,7 @@ export default class UserFieldValidations extends Service {
         .replace(/\s+/g, "-")}`;
       const userFieldElement = document.querySelector(`.${className}`);
       if (userFieldElement) {
-        userFieldElement.style.display = shouldShow ? "block" : "none";
+        userFieldElement.style.display = shouldShow ? "" : "none";
       }
     });
   }

--- a/assets/javascripts/discourse/services/user-field-validations.js
+++ b/assets/javascripts/discourse/services/user-field-validations.js
@@ -1,10 +1,13 @@
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { next } from "@ember/runloop";
-import Service from "@ember/service";
+import Service, { inject as service } from "@ember/service";
 
 export default class UserFieldValidations extends Service {
+  @service site;
+
   @tracked totalCustomValidationFields = 0;
+  @tracked userFields;
   currentCustomValidationFieldCount = 0;
 
   @action
@@ -22,14 +25,18 @@ export default class UserFieldValidations extends Service {
   @action
   crossCheckValidations(userField, value) {
     const shouldShow = userField.show_values?.includes?.(value);
-    this._updateTargets(userField.target_classes, shouldShow);
+    this._updateTargets(userField.target_user_field_ids, shouldShow);
   }
 
-  _updateTargets(targetClasses, shouldShow) {
-    targetClasses.forEach((className) => {
-      const userField = document.querySelector(`.${className}`);
-      if (userField) {
-        userField.style.display = shouldShow ? "block" : "none";
+  _updateTargets(userFieldIds, shouldShow) {
+    userFieldIds.forEach((id) => {
+      const userField = this.site.user_fields.find((field) => field.id === id);
+      const className = `user-field-${userField.name
+        .toLowerCase()
+        .replace(/\s+/g, "-")}`;
+      const userFieldElement = document.querySelector(`.${className}`);
+      if (userFieldElement) {
+        userFieldElement.style.display = shouldShow ? "block" : "none";
       }
     });
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9,7 +9,7 @@ en:
       has_custom_validation: "Include a custom validation"
       show_values:
         label: "Show Values"
-        description: "The value(s) required to have the target classes be made visible. If multiple values are provided, only one needs to be present to show the attached target class."
-      target_classes:
-        label: "Target Classes"
-        description: "The classes that will be made visible"
+        description: "The value(s) required to have the target User Field be made visible. If multiple values are provided, only one needs to be present to show the target User Field."
+      target_user_field_ids:
+        label: "Target User Fields"
+        description: "The User Field(s) that will be made visible"

--- a/db/migrate/20231222185239_add_custom_validation_fields_to_user_field.rb
+++ b/db/migrate/20231222185239_add_custom_validation_fields_to_user_field.rb
@@ -3,7 +3,7 @@
 class AddCustomValidationFieldsToUserField < ActiveRecord::Migration[7.0]
   def change
     add_column :user_fields, :has_custom_validation, :boolean, default: false, null: false
-    add_column :user_fields, :show_values, :text, array: true, default: [], null: false
-    add_column :user_fields, :target_classes, :text, array: true, default: [], null: false
+    add_column :user_fields, :show_values, :text, array: true, default: []
+    add_column :user_fields, :target_user_field_ids, :bigint, array: true, default: []
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -19,10 +19,10 @@ require_relative "lib/discourse_authentication_validations/engine"
 after_initialize do
   add_to_serializer(:user_field, :has_custom_validation) { object.has_custom_validation }
   add_to_serializer(:user_field, :show_values) { object.show_values }
-  add_to_serializer(:user_field, :target_classes) { object.target_classes }
+  add_to_serializer(:user_field, :target_user_field_ids) { object.target_user_field_ids }
 
   register_modifier(:admin_user_fields_columns) do |columns|
-    columns.push(:has_custom_validation, :show_values, :target_classes)
+    columns.push(:has_custom_validation, :show_values, :target_user_field_ids)
     columns
   end
 end

--- a/spec/system/custom_user_field_spec.rb
+++ b/spec/system/custom_user_field_spec.rb
@@ -96,9 +96,7 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field", type: 
   context "when changing the value of user field with a custom validation" do
     context "when user field is included in target_user_field_ids" do
       let(:target_class) { build_user_field_css_target(user_field_with_validation_1) }
-      let(:parent_of_target_class) do
-        build_user_field_css_target(user_field_with_validation_2)
-      end
+      let(:parent_of_target_class) { build_user_field_css_target(user_field_with_validation_2) }
 
       context "when show_values are set on parent user field of target" do
         context "when the input matches a show_values value" do

--- a/spec/system/custom_user_field_spec.rb
+++ b/spec/system/custom_user_field_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field", type: 
       required: false,
       has_custom_validation: false,
       show_values: [],
-      target_classes: [],
+      target_user_field_ids: [],
     )
   end
 
@@ -28,7 +28,7 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field", type: 
       required: false,
       has_custom_validation: true,
       show_values: [],
-      target_classes: [],
+      target_user_field_ids: [],
     )
   end
 
@@ -41,12 +41,12 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field", type: 
       required: false,
       has_custom_validation: true,
       show_values: [SHOW_VALIDATION_VALUE_1, SHOW_VALIDATION_VALUE_2],
-      target_classes: [build_user_field_name_css_target(user_field_with_validation_1, prefix: "")],
+      target_user_field_ids: [user_field_with_validation_1.id],
     )
   end
 
-  def build_user_field_name_css_target(user_field, prefix: ".")
-    "#{prefix}user-field-#{user_field.name}"
+  def build_user_field_css_target(user_field)
+    ".user-field-#{user_field.name}"
   end
 
   shared_examples "show target user field" do
@@ -67,7 +67,7 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field", type: 
 
   context "when completing the initial render of user fields" do
     context "when user field has no custom validation" do
-      let(:target_class) { build_user_field_name_css_target(user_field_without_validation) }
+      let(:target_class) { build_user_field_css_target(user_field_without_validation) }
 
       context "when rendering user field" do
         include_examples "show target user field"
@@ -75,16 +75,16 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field", type: 
     end
 
     context "when user field has custom validation" do
-      context "when user field is included in target_classes" do
-        let(:target_class) { build_user_field_name_css_target(user_field_with_validation_1) }
+      context "when user field is included in target_user_field_ids" do
+        let(:target_class) { build_user_field_css_target(user_field_with_validation_1) }
 
         context "when rendering user field" do
           include_examples "hide target user field"
         end
       end
 
-      context "when user field is not included in target_classes" do
-        let(:target_class) { build_user_field_name_css_target(user_field_with_validation_2) }
+      context "when user field is not included in target_user_field_ids" do
+        let(:target_class) { build_user_field_css_target(user_field_with_validation_2) }
 
         context "when rendering user field" do
           include_examples "show target user field"
@@ -94,10 +94,10 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field", type: 
   end
 
   context "when changing the value of user field with a custom validation" do
-    context "when user field is included in target_classes" do
-      let(:target_class) { build_user_field_name_css_target(user_field_with_validation_1) }
+    context "when user field is included in target_user_field_ids" do
+      let(:target_class) { build_user_field_css_target(user_field_with_validation_1) }
       let(:parent_of_target_class) do
-        build_user_field_name_css_target(user_field_with_validation_2)
+        build_user_field_css_target(user_field_with_validation_2)
       end
 
       context "when show_values are set on parent user field of target" do
@@ -121,8 +121,8 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field", type: 
       end
     end
 
-    context "when user field is not included in target_classes" do
-      let(:target_class) { build_user_field_name_css_target(user_field_with_validation_2) }
+    context "when user field is not included in target_user_field_ids" do
+      let(:target_class) { build_user_field_css_target(user_field_with_validation_2) }
 
       context "when rendering user field" do
         include_examples "show target user field"

--- a/test/javascripts/acceptance/custom-user-fields-test.js
+++ b/test/javascripts/acceptance/custom-user-fields-test.js
@@ -22,7 +22,7 @@ acceptance(
               position: 1,
               has_custom_validation: true,
               show_values: [],
-              target_classes: [],
+              target_user_field_ids: [],
             },
             {
               id: 2,
@@ -33,7 +33,7 @@ acceptance(
               position: 2,
               has_custom_validation: false,
               show_values: [],
-              target_classes: [],
+              target_user_field_ids: [],
             },
           ],
         })

--- a/test/javascripts/acceptance/custom-user-fields-test.js
+++ b/test/javascripts/acceptance/custom-user-fields-test.js
@@ -2,6 +2,33 @@ import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
+const userFields = {
+  user_fields: [
+    {
+      id: 1,
+      name: "test_with_validation",
+      description: "test_with_validation",
+      field_type: "text",
+      editable: true,
+      position: 1,
+      has_custom_validation: true,
+      show_values: [],
+      target_user_field_ids: [],
+    },
+    {
+      id: 2,
+      name: "test_without_validation",
+      description: "test_without_validation",
+      field_type: "text",
+      editable: true,
+      position: 2,
+      has_custom_validation: false,
+      show_values: [],
+      target_user_field_ids: [],
+    },
+  ],
+};
+
 acceptance(
   "Discourse Authentication Validations - Custom User Fields",
   function (needs) {
@@ -9,34 +36,10 @@ acceptance(
     needs.settings({
       discourse_authentication_validations_enabled: true,
     });
+    needs.site(userFields);
     needs.pretender((server, helper) => {
       server.get("/admin/customize/user_fields", () =>
-        helper.response(200, {
-          user_fields: [
-            {
-              id: 1,
-              name: "test_with_validation",
-              description: "test_with_validation",
-              field_type: "text",
-              editable: true,
-              position: 1,
-              has_custom_validation: true,
-              show_values: [],
-              target_user_field_ids: [],
-            },
-            {
-              id: 2,
-              name: "test_without_validation",
-              description: "test_without_validation",
-              field_type: "text",
-              editable: true,
-              position: 2,
-              has_custom_validation: false,
-              show_values: [],
-              target_user_field_ids: [],
-            },
-          ],
-        })
+        helper.response(200, userFields)
       );
     });
 


### PR DESCRIPTION
- Replace `target_classes` with `target_user_field_ids`. This has multiple benefits: 
  - reduce scope of `targets` to user fields only
  - improve readability of _what are we targeting_
  - relying on user field id preserves uniqueness of target, unlike looking up a user field by a name
  
- Update tests
- Update logic relying upon `target_classes`

<img width="778" alt="Screenshot 2024-01-04 at 11 25 58 AM" src="https://github.com/discourse/discourse-authentication-validations/assets/50783505/a54a7796-c654-4bdb-9a6d-06c54eb20d6a">
