### PR TITLE
DEV: Update constants in tests

### DIFF
--- a/spec/system/custom_dropdown_field_user_field_spec.rb
+++ b/spec/system/custom_dropdown_field_user_field_spec.rb
@@ -174,6 +174,8 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field - Dropdo
         select_kit.expand
         select_kit.select_row_by_value(NOT_A_SHOW_VALIDATION_VALUE)
 
+        puts user_field_with_validation_2.show_values.inspect
+
         expect(page).not_to have_css(target_class)
       end
     end

--- a/spec/system/custom_dropdown_field_user_field_spec.rb
+++ b/spec/system/custom_dropdown_field_user_field_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe "Discourse Authentication Validation - Custom User Field - Dropdown Field",
                type: :system,
                js: true do
-  SHOW_VALIDATION_VALUE = "show_validation"
-  NOT_A_SHOW_VALIDATION_VALUE = "not a show_values value"
+  SHOW_VALIDATION_VALUE ||= "show_validation"
+  NOT_A_SHOW_VALIDATION_VALUE ||= "not a show_values value"
 
   before { SiteSetting.discourse_authentication_validations_enabled = true }
 

--- a/spec/system/custom_text_field_user_field_spec.rb
+++ b/spec/system/custom_text_field_user_field_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "Discourse Authentication Validation - Custom User Field - Text Field",
                type: :system,
                js: true do
-  SHOW_VALIDATION_VALUE = "show_validation"
+  SHOW_VALIDATION_VALUE ||= "show_validation"
 
   before { SiteSetting.discourse_authentication_validations_enabled = true }
 


### PR DESCRIPTION
Conditionally set the test constants to resolve 

> discourse-authentication-validations/spec/system/custom_dropdown_field_user_field_spec.rb:6: warning: previous definition of SHOW_VALIDATION_VALUE was here

during test runs
