### PR TITLE
FEATURE: Add value validation regex

### DIFF
--- a/assets/javascripts/discourse/connectors/after-admin-user-fields/custom-user-fields.gjs
+++ b/assets/javascripts/discourse/connectors/after-admin-user-fields/custom-user-fields.gjs
@@ -18,9 +18,12 @@ export default class CustomUserFields extends Component {
   constructor() {
     super(...arguments);
     withPluginApi("1.21.0", (api) => {
-      ["has_custom_validation", "show_values", "target_user_field_ids"].forEach(
-        (property) => api.includeUserFieldPropertyOnSave(property)
-      );
+      [
+        "has_custom_validation",
+        "show_values",
+        "target_user_field_ids",
+        "value_validation_regex",
+      ].forEach((property) => api.includeUserFieldPropertyOnSave(property));
     });
   }
 
@@ -37,6 +40,21 @@ export default class CustomUserFields extends Component {
     </AdminFormRow>
 
     {{#if @outletArgs.buffered.has_custom_validation}}
+      <AdminFormRow
+        @label="discourse_authentication_validations.value_validation_regex.label"
+      >
+        <Input
+          @value={{@outletArgs.buffered.value_validation_regex}}
+          class="value-validation-regex-input"
+        />
+        <br />
+        <span>
+          {{i18n
+            "discourse_authentication_validations.value_validation_regex.description"
+          }}
+        </span>
+      </AdminFormRow>
+
       <AdminFormRow
         @label="discourse_authentication_validations.show_values.label"
       >
@@ -59,6 +77,7 @@ export default class CustomUserFields extends Component {
           @content={{this.userFieldsMinusCurrent}}
           @valueProperty="id"
           @value={{@outletArgs.buffered.target_user_field_ids}}
+          class="target-user-field-ids-input"
         />
         <br />
         <span>

--- a/assets/javascripts/discourse/connectors/after-admin-user-fields/custom-user-fields.gjs
+++ b/assets/javascripts/discourse/connectors/after-admin-user-fields/custom-user-fields.gjs
@@ -1,7 +1,10 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { Input } from "@ember/component";
+import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
 import { inject as service } from "@ember/service";
+import withEventValue from "discourse/helpers/with-event-value";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import i18n from "discourse-common/helpers/i18n";
 import AdminFormRow from "admin/components/admin-form-row";
@@ -43,8 +46,15 @@ export default class CustomUserFields extends Component {
       <AdminFormRow
         @label="discourse_authentication_validations.value_validation_regex.label"
       >
-        <Input
-          @value={{@outletArgs.buffered.value_validation_regex}}
+        <input
+          {{on
+            "input"
+            (withEventValue
+              (fn (mut @outletArgs.buffered.value_validation_regex))
+            )
+          }}
+          value={{@outletArgs.buffered.value_validation_regex}}
+          type="text"
           class="value-validation-regex-input"
         />
         <br />

--- a/assets/javascripts/discourse/initializers/user-field-validation.js
+++ b/assets/javascripts/discourse/initializers/user-field-validation.js
@@ -1,0 +1,35 @@
+import EmberObject from "@ember/object";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import I18n from "discourse-i18n";
+
+export default {
+  name: "user-field-validation",
+  initialize() {
+    withPluginApi("1.33.0", (api) => {
+      api.addCustomUserFieldValidationCallback((userField) => {
+        if (
+          userField.field.has_custom_validation &&
+          userField.field.value_validation_regex &&
+          userField.value
+        ) {
+          if (
+            !new RegExp(userField.field.value_validation_regex).test(
+              userField.value
+            )
+          ) {
+            return EmberObject.create({
+              failed: true,
+              reason: I18n.t(
+                "discourse_authentication_validations.value_validation_error_message",
+                {
+                  user_field_name: userField.field.name,
+                }
+              ),
+              element: userField.field.element,
+            });
+          }
+        }
+      });
+    });
+  },
+};

--- a/assets/stylesheets/common/admin/common.scss
+++ b/assets/stylesheets/common/admin/common.scss
@@ -1,0 +1,4 @@
+.show-values-input,
+.target-user-field-ids-input {
+  margin: 0.4em 0;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -13,3 +13,8 @@ en:
       target_user_field_ids:
         label: "Target User Fields"
         description: "The User Field(s) that will be made visible"
+      value_validation_regex:
+        label: "Value Validation Regex"
+        description: "The regular expression that the value must match (only applicable to text fields)"
+      value_validation_error_message: |
+        Please enter a valid %{user_field_name}

--- a/db/migrate/20240605190725_add_value_validation_regex_to_user_field.rb
+++ b/db/migrate/20240605190725_add_value_validation_regex_to_user_field.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddValueValidationRegexToUserField < ActiveRecord::Migration[7.0]
+  def change
+    add_column :user_fields, :value_validation_regex, :string, default: "", null: true
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -10,6 +10,8 @@
 
 enabled_site_setting :discourse_authentication_validations_enabled
 
+register_asset "stylesheets/common/admin/common.scss"
+
 module ::DiscourseAuthenticationValidations
   PLUGIN_NAME = "discourse-authentication-validations"
 end
@@ -20,9 +22,15 @@ after_initialize do
   add_to_serializer(:user_field, :has_custom_validation) { object.has_custom_validation }
   add_to_serializer(:user_field, :show_values) { object.show_values }
   add_to_serializer(:user_field, :target_user_field_ids) { object.target_user_field_ids }
+  add_to_serializer(:user_field, :value_validation_regex) { object.value_validation_regex }
 
   register_modifier(:admin_user_fields_columns) do |columns|
-    columns.push(:has_custom_validation, :show_values, :target_user_field_ids)
+    columns.push(
+      :has_custom_validation,
+      :show_values,
+      :target_user_field_ids,
+      :value_validation_regex,
+    )
     columns
   end
 end

--- a/spec/system/value_validation_regex_user_field_spec.rb
+++ b/spec/system/value_validation_regex_user_field_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+RSpec.describe "Discourse Authentication Validation - Value Validation Regex - User Field",
+               type: :system do
+  let(:signup_modal) { PageObjects::Modals::Signup.new }
+  fab!(:user_field_with_value_validation_regex) do
+    Fabricate(
+      :user_field,
+      name: "phone number",
+      field_type: "text",
+      editable: true,
+      required: true,
+      has_custom_validation: true,
+      show_values: [],
+      target_user_field_ids: [],
+      value_validation_regex: "^\\d{2} \\d{4} \\d{4}$", # 00 0000 0000
+    )
+  end
+
+  fab!(:user_field_without_value_validation_regex) do
+    Fabricate(
+      :user_field,
+      name: "unvalidated phone number",
+      field_type: "text",
+      editable: true,
+      required: true,
+      has_custom_validation: true,
+      show_values: [],
+      target_user_field_ids: [],
+      value_validation_regex: nil,
+    )
+  end
+
+  before { SiteSetting.discourse_authentication_validations_enabled = true }
+
+  context "when a user field has a value_validation_regex" do
+    it "displays a validation error message when the target user field input is incorrect" do
+      signup_modal.open
+      signup_modal.fill_custom_field("phone-number", "not a phone number")
+      signup_modal.click_create_account
+
+      expect(signup_modal).to have_text(
+        I18n.t(
+          "js.discourse_authentication_validations.value_validation_error_message",
+          { user_field_name: user_field_with_value_validation_regex.name },
+        ),
+      )
+    end
+
+    it "displays the default error message for no value" do
+      signup_modal.open
+      signup_modal.click_create_account
+
+      expect(signup_modal).not_to have_text(
+        I18n.t(
+          "js.discourse_authentication_validations.value_validation_error_message",
+          { user_field_name: user_field_with_value_validation_regex.name },
+        ),
+      )
+      expect(signup_modal).to have_text(
+        I18n.t("js.user_fields.required", { name: user_field_with_value_validation_regex.name }),
+      )
+    end
+
+    it "clears the validation error message when the target user field input is correct" do
+      signup_modal.open
+      signup_modal.fill_custom_field("phone-number", "not a phone number")
+      signup_modal.click_create_account
+
+      signup_modal.fill_custom_field("phone-number", "11 2222 3333")
+      signup_modal.click_create_account
+
+      expect(signup_modal).not_to have_text(
+        I18n.t(
+          "js.discourse_authentication_validations.value_validation_error_message",
+          { user_field_name: user_field_with_value_validation_regex.name },
+        ),
+      )
+    end
+  end
+
+  context "when a user field does not have a value_validation_regex" do
+    it "does not display a validation error message" do
+      signup_modal.open
+      signup_modal.fill_custom_field("unvalidated-phone-number", "not a phone number")
+      signup_modal.click_create_account
+
+      expect(signup_modal).not_to have_text(
+        I18n.t(
+          "js.discourse_authentication_validations.value_validation_error_message",
+          { user_field_name: user_field_without_value_validation_regex.name },
+        ),
+      )
+    end
+  end
+
+  context "when a user field has a value_validation_regex and has_custom_validation is false" do
+    it "does not display a validation error message" do
+      user_field_with_value_validation_regex.update!(has_custom_validation: false)
+      signup_modal.open
+      signup_modal.fill_custom_field("phone-number", "not a phone number")
+      signup_modal.click_create_account
+
+      expect(signup_modal).not_to have_text(
+        I18n.t(
+          "js.discourse_authentication_validations.value_validation_error_message",
+          { user_field_name: user_field_with_value_validation_regex.name },
+        ),
+      )
+    end
+  end
+end

--- a/test/javascripts/acceptance/admin-page-custom-user-fields-test.js
+++ b/test/javascripts/acceptance/admin-page-custom-user-fields-test.js
@@ -30,7 +30,7 @@ const userFields = {
 };
 
 acceptance(
-  "Discourse Authentication Validations - Custom User Fields",
+  "Discourse Authentication Validations - Admin Page - Custom User Fields",
   function (needs) {
     needs.user();
     needs.settings({


### PR DESCRIPTION
Relies upon: https://github.com/discourse/discourse/pull/27369

Custom User Fields do not have any type of `validation` provided by core, outside of detecting an empty value on a required field. This PR adds the ability to define a regex, per custom user field, that will then be checked against the provided input value. 

# Preview

### Admin
Create a user custom field and add a `value validation regex`

<img width="729" alt="Screenshot 2024-06-05 at 11 18 20 PM" src="https://github.com/discourse/discourse-authentication-validations/assets/50783505/ace15c47-a270-44d3-a539-fcb57cdfc94c">

The user custom field's value on the signup form will now be tested against the regex you have included.

### No value (relies on default form validation)
<img width="291" alt="Screenshot 2024-06-05 at 11 07 04 PM" src="https://github.com/discourse/discourse-authentication-validations/assets/50783505/30a7edbb-8531-49ae-8e71-ca365fb8d2ed">


### Incorrect value
<img width="282" alt="Screenshot 2024-06-05 at 11 07 40 PM" src="https://github.com/discourse/discourse-authentication-validations/assets/50783505/8eac87e4-1011-4544-92ca-e63f02931d52">

### Correct value
<img width="293" alt="Screenshot 2024-06-05 at 11 08 02 PM" src="https://github.com/discourse/discourse-authentication-validations/assets/50783505/23aab11a-e083-4631-bb12-435d18d95a2c">

