### PR TITLE
DEV: Update system tests and fix flake

### DIFF
--- a/spec/system/custom_text_field_user_field_spec.rb
+++ b/spec/system/custom_text_field_user_field_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe "Discourse Authentication Validation - Custom User Field - Text Field",
-               type: :system,
-               js: true do
-  SHOW_VALIDATION_VALUE = "show_validation"
-
+               type: :system do
   before { SiteSetting.discourse_authentication_validations_enabled = true }
+
+  let(:custom_validation_page) { PageObjects::Pages::CustomValidation.new }
 
   fab!(:user_field_without_validation) do
     Fabricate(
@@ -41,71 +40,55 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field - Text F
       editable: true,
       required: false,
       has_custom_validation: true,
-      show_values: [SHOW_VALIDATION_VALUE],
+      show_values: ["show_validation"],
       target_user_field_ids: [user_field_with_validation_1.id],
     )
   end
 
-  def build_user_field_css_target(user_field)
-    ".user-field-#{user_field.name}"
-  end
-
-  context "when user field has no custom validation" do
-    let(:target_class) { build_user_field_css_target(user_field_without_validation) }
-
-    it "shows the target user field" do
-      visit("/signup")
-      expect(page).to have_css(target_class)
-    end
+  it "shows the target user field when user field has no custom validation" do
+    visit("/signup")
+    expect(page).to have_css(custom_validation_page.target_class(user_field_without_validation))
   end
 
   context "when user field has custom validation" do
-    context "when user field is included in target_user_field_ids" do
-      let(:target_class) { build_user_field_css_target(user_field_with_validation_1) }
+    before { visit("/signup") }
 
-      it "hides the target user field" do
-        visit("/signup")
-        expect(page).not_to have_css(target_class)
-      end
+    it "hides the target user field when user field is included in target_user_field_ids" do
+      expect(page).to have_no_css(custom_validation_page.target_class(user_field_with_validation_1))
     end
 
-    context "when user field is not included in target_user_field_ids" do
-      let(:target_class) { build_user_field_css_target(user_field_with_validation_2) }
-
-      it "shows the target user field" do
-        visit("/signup")
-        expect(page).to have_css(target_class)
-      end
+    it "shows the target user field when user field is not included in target_user_field_ids" do
+      expect(page).to have_css(custom_validation_page.target_class(user_field_with_validation_2))
     end
   end
 
   context "when changing the value of user field with a custom validation and user field is included in target_user_field_ids" do
-    let(:target_class) { build_user_field_css_target(user_field_with_validation_1) }
-    let(:parent_of_target_class) { build_user_field_css_target(user_field_with_validation_2) }
+    before { visit("/signup") }
 
-    context "when show_values are set on parent user field of target" do
-      context "when the input matches a show_values value" do
-        it "shows the target user field" do
-          visit("/signup")
-          page.find(parent_of_target_class).fill_in(with: SHOW_VALIDATION_VALUE)
-          expect(page).to have_css(target_class)
-        end
-      end
-
-      context "when the input does not match a show_values value" do
-        it "hides the target user field" do
-          visit("/signup")
-          page.find(parent_of_target_class).fill_in(with: "not a show_values value")
-          expect(page).not_to have_css(target_class)
-        end
-      end
+    it "hides the target user field when show_values are not set on parent user field of target" do
+      page.find(custom_validation_page.target_class(user_field_with_validation_2)).fill_in(
+        with: "foo bar",
+      )
+      expect(page).not_to have_css(
+        custom_validation_page.target_class(user_field_with_validation_1),
+      )
     end
 
-    context "when show_values are not set on parent user field of target" do
-      it "hides the target user field" do
-        visit("/signup")
-        page.find(parent_of_target_class).fill_in(with: "foo bar")
-        expect(page).not_to have_css(target_class)
+    context "when show_values are set on parent user field of target" do
+      it "shows the target user field when the input matches a show_values value" do
+        page.find(custom_validation_page.target_class(user_field_with_validation_2)).fill_in(
+          with: custom_validation_page.show_value_validation_value,
+        )
+        expect(page).to have_css(custom_validation_page.target_class(user_field_with_validation_1))
+      end
+
+      it "hides the target user field when the input does not match a show_values value" do
+        page.find(custom_validation_page.target_class(user_field_with_validation_2)).fill_in(
+          with: custom_validation_page.not_a_show_value_validation_value,
+        )
+        expect(page).not_to have_css(
+          custom_validation_page.target_class(user_field_with_validation_1),
+        )
       end
     end
   end

--- a/spec/system/page_objects/custom_validation.rb
+++ b/spec/system/page_objects/custom_validation.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class CustomValidation < PageObjects::Pages::Base
+      def select_not_show_validation_value(selector)
+        select_kit = PageObjects::Components::SelectKit.new("#{selector} .select-kit")
+        select_kit.expand
+        select_kit.select_row_by_value(self.not_a_show_value_validation_value)
+      end
+
+      def select_show_validation_value(selector)
+        select_kit = PageObjects::Components::SelectKit.new("#{selector} .select-kit")
+        select_kit.expand
+        select_kit.select_row_by_value(self.show_value_validation_value)
+      end
+
+      def build_user_field_css_target(user_field)
+        ".user-field-#{user_field.name}"
+      end
+
+      def target_class(user_field)
+        build_user_field_css_target(user_field)
+      end
+
+      def show_value_validation_value
+        "show_validation"
+      end
+
+      def not_a_show_value_validation_value
+        "not a show_values value"
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Remove unnecessary `context` blocks
- Move away from `.not_to have_css` in favor of `.to have_no_css`
- Remove `js: true`
- Remove constant definitions in specs, it was causing weird errors due to previous constant definitions persisting across tests
- Introduce page object for simplification of specs