### PR TITLE
DEV: Hide and clear nested user fields

### DIFF
--- a/assets/javascripts/discourse/services/user-field-validations.js
+++ b/assets/javascripts/discourse/services/user-field-validations.js
@@ -70,7 +70,8 @@ export default class UserFieldValidations extends Service {
   }
 
   _shouldShow(userField, value) {
-    let shouldShow = userField.show_values.includes(value);
+    let stringValue = value?.toString(); // Account for checkbox boolean values and `null`
+    let shouldShow = userField.show_values.includes(stringValue);
     if (value === null && userField.show_values.includes("null")) {
       shouldShow = true;
     }

--- a/assets/javascripts/discourse/services/user-field-validations.js
+++ b/assets/javascripts/discourse/services/user-field-validations.js
@@ -1,13 +1,12 @@
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { next } from "@ember/runloop";
-import Service, { inject as service } from "@ember/service";
+import Service, { service } from "@ember/service";
 
 export default class UserFieldValidations extends Service {
   @service site;
 
   @tracked totalCustomValidationFields = 0;
-  @tracked userFields;
   currentCustomValidationFieldCount = 0;
 
   @action
@@ -18,17 +17,39 @@ export default class UserFieldValidations extends Service {
       this.currentCustomValidationFieldCount ===
       this.totalCustomValidationFields
     ) {
-      next(() => this.crossCheckValidations(userField, value));
+      next(() => {
+        this.crossCheckValidations(userField, value);
+        this.hideNestedCustomValidations(userField, value);
+      });
+    }
+  }
+
+  @action
+  hideNestedCustomValidations(userField, value) {
+    if (!this._shouldShow(userField, value)) {
+      const nestedUserFields = this.site.user_fields
+        .filter((field) => userField.target_user_field_ids.includes(field.id))
+        .flatMap((nestedField) =>
+          this.site.user_fields.filter((field) =>
+            nestedField.target_user_field_ids.includes(field.id)
+          )
+        );
+
+      // Clear and hide nested fields
+      nestedUserFields.forEach((field) => this._clearUserField(field));
+      this._updateTargets(
+        nestedUserFields.map((field) => field.id),
+        false
+      );
     }
   }
 
   @action
   crossCheckValidations(userField, value) {
-    let shouldShow = userField.show_values.includes(value);
-    if (value === null && userField.show_values.includes("null")) {
-      shouldShow = true;
-    }
-    this._updateTargets(userField.target_user_field_ids, shouldShow);
+    this._updateTargets(
+      userField.target_user_field_ids,
+      this._shouldShow(userField, value)
+    );
   }
 
   _updateTargets(userFieldIds, shouldShow) {
@@ -38,10 +59,36 @@ export default class UserFieldValidations extends Service {
         .toLowerCase()
         .replace(/\s+/g, "-")}`;
       const userFieldElement = document.querySelector(`.${className}`);
-      if (userFieldElement) {
-        userFieldElement.style.display = shouldShow ? "" : "none";
+      if (userFieldElement && !shouldShow) {
+        // Clear and hide nested fields
+        userFieldElement.style.display = "none";
+        this._clearUserField(userField);
+      } else {
+        userFieldElement.style.display = "";
       }
     });
+  }
+
+  _shouldShow(userField, value) {
+    let shouldShow = userField.show_values.includes(value);
+    if (value === null && userField.show_values.includes("null")) {
+      shouldShow = true;
+    }
+    return shouldShow;
+  }
+
+  _clearUserField(userField) {
+    switch (userField.field_type) {
+      case "confirm":
+        userField.element.checked = false;
+        break;
+      case "dropdown":
+        userField.element.selectedIndex = 0;
+        break;
+      default:
+        userField.element.value = "";
+        break;
+    }
   }
 
   _bumpTotalCustomValidationFields() {

--- a/spec/system/custom_confirm_field_user_field_spec.rb
+++ b/spec/system/custom_confirm_field_user_field_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Discourse Authentication Validation - Custom User Field - Dropdown Field",
+RSpec.describe "Discourse Authentication Validation - Custom User Field - Confirm Field",
                type: :system do
   let(:custom_validation_page) { PageObjects::Pages::CustomValidation.new }
 
@@ -8,72 +8,91 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field - Dropdo
     Fabricate(
       :user_field,
       name: "without_validation",
-      field_type: "dropdown",
+      field_type: "confirm",
       editable: true,
       required: false,
       has_custom_validation: false,
       show_values: [],
       target_user_field_ids: [],
-    ) { user_field_options { [Fabricate(:user_field_option, value: "not a show_values value")] } }
-  end
-
-  fab!(:user_field_without_validation_2) do
-    Fabricate(
-      :user_field,
-      name: "without_validation_2",
-      field_type: "dropdown",
-      editable: true,
-      required: false,
-      has_custom_validation: false,
-      show_values: [],
-      target_user_field_ids: [],
-    ) { user_field_options { [Fabricate(:user_field_option, value: "not a show_values value")] } }
+    )
   end
 
   fab!(:user_field_with_validation_1) do
     Fabricate(
       :user_field,
       name: "with_validation_1",
-      field_type: "dropdown",
+      field_type: "confirm",
       editable: true,
       required: false,
       has_custom_validation: true,
       show_values: [],
       target_user_field_ids: [],
-    ) { user_field_options { [Fabricate(:user_field_option, value: "not a show_values value")] } }
+    )
   end
 
-  fab!(:user_field_with_validation_2) do
+  fab!(:user_field_without_validation_2) do
     Fabricate(
       :user_field,
-      name: "with_validation_2",
-      field_type: "dropdown",
+      name: "without_validation_2",
+      field_type: "confirm",
       editable: true,
       required: false,
-      has_custom_validation: true,
-      show_values: ["show_validation"],
-      target_user_field_ids: [user_field_with_validation_1.id],
-    ) do
-      user_field_options do
-        [
-          Fabricate(:user_field_option, value: "not a show_values value"),
-          Fabricate(:user_field_option, value: "show_validation"),
-        ]
-      end
-    end
+      has_custom_validation: false,
+      show_values: [],
+      target_user_field_ids: [],
+    )
   end
 
   fab!(:user_field_with_validation_3) do
     Fabricate(
       :user_field,
       name: "with_validation_3",
-      field_type: "dropdown",
+      field_type: "confirm",
       editable: true,
       required: false,
       has_custom_validation: true,
       show_values: ["null"],
       target_user_field_ids: [user_field_without_validation_2.id],
-    ) { user_field_options { [Fabricate(:user_field_option, value: "not a show_values value")] } }
+    )
+  end
+
+  fab!(:user_field_with_validation_2) do
+    Fabricate(
+      :user_field,
+      name: "with_validation_2",
+      field_type: "confirm",
+      editable: true,
+      required: false,
+      has_custom_validation: true,
+      show_values: ["true"],
+      target_user_field_ids: [user_field_with_validation_1.id],
+    )
+  end
+
+  fab!(:user_field_without_validation_3) do
+    Fabricate(
+      :user_field,
+      name: "without_validation_3",
+      field_type: "confirm",
+      editable: true,
+      required: false,
+      has_custom_validation: false,
+      show_values: [],
+      target_user_field_ids: [],
+    )
+  end
+
+  fab!(:user_field_with_validation_4) do
+    Fabricate(
+      :user_field,
+      name: "with_validation_4",
+      field_type: "confirm",
+      editable: true,
+      required: false,
+      has_custom_validation: true,
+      show_values: [],
+      target_user_field_ids: [user_field_without_validation_3.id],
+    )
   end
 
   before do
@@ -93,29 +112,26 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field - Dropdo
     expect(page).to have_css(custom_validation_page.target_class(user_field_with_validation_2))
   end
 
-  context "when show_values are set on parent" do
-    it "shows the child when the input matches a show_values value" do
-      custom_validation_page.select_show_validation_value(
+  context "when show_values is set to 'true'" do
+    it "shows the child when checked" do
+      custom_validation_page.click_confirmation(
         custom_validation_page.target_class(user_field_with_validation_2),
       )
       expect(page).to have_css(custom_validation_page.target_class(user_field_with_validation_1))
     end
 
-    it "hides child when the input does not match a show_values value" do
-      custom_validation_page.select_not_show_validation_value(
-        custom_validation_page.target_class(user_field_with_validation_2),
-      )
+    it "hides child when not checked" do
       expect(page).to have_no_css(custom_validation_page.target_class(user_field_with_validation_1))
     end
   end
 
-  context "when show_values includes `null`" do
-    it "shows the child" do
+  context "when show_values includes 'null'" do
+    it "shows child" do
       expect(page).to have_css(custom_validation_page.target_class(user_field_without_validation_2))
     end
 
     it "toggles the display of the child after the value has changed" do
-      custom_validation_page.select_not_show_validation_value(
+      custom_validation_page.click_confirmation(
         custom_validation_page.target_class(user_field_with_validation_3),
       )
       expect(page).to have_no_css(
@@ -125,13 +141,13 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field - Dropdo
   end
 
   context "when show_values are not set" do
-    before { user_field_with_validation_2.show_values = [] }
-
     it "hides the child" do
-      custom_validation_page.select_not_show_validation_value(
-        custom_validation_page.target_class(user_field_with_validation_2),
+      custom_validation_page.click_confirmation(
+        custom_validation_page.target_class(user_field_with_validation_4),
       )
-      expect(page).to have_no_css(custom_validation_page.target_class(user_field_with_validation_1))
+      expect(page).to have_no_css(
+        custom_validation_page.target_class(user_field_without_validation_3),
+      )
     end
   end
 end

--- a/spec/system/custom_text_field_user_field_spec.rb
+++ b/spec/system/custom_text_field_user_field_spec.rb
@@ -2,8 +2,6 @@
 
 RSpec.describe "Discourse Authentication Validation - Custom User Field - Text Field",
                type: :system do
-  before { SiteSetting.discourse_authentication_validations_enabled = true }
-
   let(:custom_validation_page) { PageObjects::Pages::CustomValidation.new }
 
   fab!(:user_field_without_validation) do
@@ -32,6 +30,32 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field - Text F
     )
   end
 
+  fab!(:user_field_without_validation_2) do
+    Fabricate(
+      :user_field,
+      name: "without_validation_2",
+      field_type: "text",
+      editable: true,
+      required: false,
+      has_custom_validation: false,
+      show_values: [],
+      target_user_field_ids: [],
+    )
+  end
+
+  fab!(:user_field_with_validation_3) do
+    Fabricate(
+      :user_field,
+      name: "with_validation_3",
+      field_type: "text",
+      editable: true,
+      required: false,
+      has_custom_validation: true,
+      show_values: ["show_validation"],
+      target_user_field_ids: [user_field_without_validation_2.id],
+    )
+  end
+
   fab!(:user_field_with_validation_2) do
     Fabricate(
       :user_field,
@@ -41,55 +65,92 @@ RSpec.describe "Discourse Authentication Validation - Custom User Field - Text F
       required: false,
       has_custom_validation: true,
       show_values: ["show_validation"],
-      target_user_field_ids: [user_field_with_validation_1.id],
+      target_user_field_ids: [user_field_with_validation_1.id, user_field_with_validation_3.id],
     )
   end
 
-  it "shows the target user field when user field has no custom validation" do
+  before do
+    SiteSetting.discourse_authentication_validations_enabled = true
     visit("/signup")
+  end
+
+  it "hides child when included in target_user_field_ids" do
+    expect(page).to have_no_css(custom_validation_page.target_class(user_field_with_validation_1))
+  end
+
+  it "displays child when not included in target_user_field_ids" do
+    expect(page).to have_css(custom_validation_page.target_class(user_field_with_validation_2))
+  end
+
+  it "shows child when parent has no custom validation" do
     expect(page).to have_css(custom_validation_page.target_class(user_field_without_validation))
   end
 
-  context "when user field has custom validation" do
-    before { visit("/signup") }
-
-    it "hides the target user field when user field is included in target_user_field_ids" do
+  context "when updating input value with a custom validation" do
+    it "hides child when show_values not set on parent" do
+      page.find(custom_validation_page.target_class(user_field_with_validation_2)).fill_in(
+        with: "not a show value",
+      )
       expect(page).to have_no_css(custom_validation_page.target_class(user_field_with_validation_1))
     end
 
-    it "shows the target user field when user field is not included in target_user_field_ids" do
-      expect(page).to have_css(custom_validation_page.target_class(user_field_with_validation_2))
-    end
-  end
-
-  context "when changing the value of user field with a custom validation and user field is included in target_user_field_ids" do
-    before { visit("/signup") }
-
-    it "hides the target user field when show_values are not set on parent user field of target" do
+    it "shows the child when the input matches a show_values value on parent" do
       page.find(custom_validation_page.target_class(user_field_with_validation_2)).fill_in(
-        with: "foo bar",
+        with: "show_validation",
       )
-      expect(page).not_to have_css(
-        custom_validation_page.target_class(user_field_with_validation_1),
-      )
+      expect(page).to have_css(custom_validation_page.target_class(user_field_with_validation_3))
     end
 
-    context "when show_values are set on parent user field of target" do
-      it "shows the target user field when the input matches a show_values value" do
-        page.find(custom_validation_page.target_class(user_field_with_validation_2)).fill_in(
-          with: custom_validation_page.show_value_validation_value,
-        )
-        expect(page).to have_css(custom_validation_page.target_class(user_field_with_validation_1))
-      end
+    it "hides the child when the input does not match a show_values value on parent" do
+      page.find(custom_validation_page.target_class(user_field_with_validation_2)).fill_in(
+        with: "not a show value",
+      )
+      expect(page).to have_no_css(custom_validation_page.target_class(user_field_with_validation_1))
+    end
 
-      it "hides the target user field when the input does not match a show_values value" do
-        page.find(custom_validation_page.target_class(user_field_with_validation_2)).fill_in(
-          with: custom_validation_page.not_a_show_value_validation_value,
-        )
-        expect(page).not_to have_css(
-          custom_validation_page.target_class(user_field_with_validation_1),
-        )
-      end
+    it "shows the nested child when the input matches a show_values value on nested parent" do
+      page.find(custom_validation_page.target_class(user_field_with_validation_2)).fill_in(
+        with: "show_validation",
+      )
+      page.find(custom_validation_page.target_class(user_field_with_validation_3)).fill_in(
+        with: "show_validation",
+      )
+      expect(page).to have_css(custom_validation_page.target_class(user_field_without_validation_2))
+    end
+
+    it "clears the nested child when the input does not match a show_values value on grandparent" do
+      page.find(custom_validation_page.target_class(user_field_with_validation_2)).fill_in(
+        with: "show_validation",
+      )
+      page.find(custom_validation_page.target_class(user_field_with_validation_3)).fill_in(
+        with: "show_validation",
+      )
+      # Add a value to the nested child, so we can check that it is cleared after the grandparent is changed
+      page.find(custom_validation_page.target_class(user_field_without_validation_2)).fill_in(
+        with: "should_be_cleared",
+      )
+
+      # Update grandparent
+      page.find(custom_validation_page.target_class(user_field_with_validation_2)).fill_in(
+        with: "not a show validation",
+      )
+      # Since the grandparent was updated, we expect that the nested child is also hidden, and the parent should be cleared
+      expect(page).to have_no_css(
+        custom_validation_page.target_class(user_field_without_validation_2),
+      )
+
+      # Update grandparent and parent to show the nested child again
+      page.find(custom_validation_page.target_class(user_field_with_validation_2)).fill_in(
+        with: "show_validation",
+      )
+      page.find(custom_validation_page.target_class(user_field_with_validation_3)).fill_in(
+        with: "show_validation",
+      )
+      expect(page).to have_css(custom_validation_page.target_class(user_field_without_validation_2))
+      # Check that the nested child is cleared
+      expect(
+        page.find(custom_validation_page.target_class(user_field_without_validation_2)),
+      ).to have_text("")
     end
   end
 end

--- a/spec/system/page_objects/custom_validation.rb
+++ b/spec/system/page_objects/custom_validation.rb
@@ -15,6 +15,10 @@ module PageObjects
         select_kit.select_row_by_value(self.show_value_validation_value)
       end
 
+      def click_confirmation(selector)
+        find("#{selector}.confirm input").click
+      end
+
       def build_user_field_css_target(user_field)
         ".user-field-#{user_field.name}"
       end


### PR DESCRIPTION
# Preview


https://github.com/user-attachments/assets/c8ba3cf3-5b81-47dc-8401-2c0f30744d40


https://github.com/user-attachments/assets/339b3ecc-45ae-4eaa-92dd-751a5388ad9a



# Context 

https://meta.discourse.org/t/discourse-authentication-validations/292547/6?u=isaac

> I noticed that question responses are saved, even if a question is hidden.

> This behavior also causes another situation where when a question is double nested, it still appears even though the parent response has been deselected (because it still thinks the triggering answer is selected).

# Details

- Add and update tests for custom text-field inputs
- Add and update tests for custom confirm inputs (checkbox) 
- Add system spec for showing and hiding nested inputs
- Hide and clear nested inputs up to 2 levels of nesting, see caveats below. 

### Caveats

1. We will hide inputs **up to** 2 levels of nesting. For example, if our custom field nesting is setup as so: Parent -> child -> nested child - We will hide and clear the input of the nested child when the value of the Parent changes. 

2. The value of a nested dropdowns **will not be cleared** (it will be hidden as expected though). Only nested text field and checkbox inputs will be cleared.