### PR TITLE
FIX: broken spec

### DIFF
--- a/spec/system/page_objects/custom_validation.rb
+++ b/spec/system/page_objects/custom_validation.rb
@@ -16,7 +16,7 @@ module PageObjects
       end
 
       def click_confirmation(selector)
-        find("#{selector}.confirm input").click
+        find("#{selector}.confirm span").click
       end
 
       def build_user_field_css_target(user_field)


### PR DESCRIPTION
For an unknown reason a click on the input was only focusing the input, you would need to click two times or rely on the label click.